### PR TITLE
Fix ugly LaTeX in MS6

### DIFF
--- a/latex/milestone-6/main.tex
+++ b/latex/milestone-6/main.tex
@@ -49,10 +49,9 @@ An Introduction to Climate Modeling}\\
 \section{Fixing Stability in the spatial 2D Energy Balance Model}
 \begin{enumerate}
 
-\item In the previous milestone you have implemented the spatial operator of the diffusive EBM for two spatial dimensions. The investigations of the eigenvalues revealed that the stable time step of the explicit Euler method is prohibitively small. Hence, we focus on the implicit Euler method. Adapt the function\\
-csmall\texttt{\detokenize{calc_equilibrium_2d }}\normalsize to use the backward Euler instead of the forward Euler time integration method. Visualize the results as an animation.
+\item In the previous milestone you have implemented the spatial operator of the diffusive EBM for two spatial dimensions. The investigations of the eigenvalues revealed that the stable time step of the explicit Euler method is prohibitively small. Hence, we focus on the implicit Euler method in this milestone. Adapt the function {\small\texttt{\detokenize{calc_equilibrium_2d}}} to use the backward Euler instead of the forward Euler time integration method. Visualize the results as an animation.
 
-\item  Use the functions \small\texttt{\detokenize{calc_area_mean}}\normalsize, \small\texttt{\detokenize{calc_area_mean_north }}\normalsize and \small\texttt{\detokenize{calc_area_mean_south }}\normalsize  from previous milestones to compute the mean temperature values from the EBM in two space dimensions. Compare them with the results in milestone 4. Compare also the results for the temperature in Cologne. What is noticeable?
+\item  Use the functions {\small\texttt{\detokenize{calc_area_mean}}}, {\small\texttt{\detokenize{calc_area_mean_north}}} and {\small\texttt{\detokenize{calc_area_mean_south}}} from previous milestones to compute the mean temperature values from the EBM in two space dimensions. Compare them with the results in milestone 4. Compare also the results for the temperature in Cologne. What is noticeable?
 
 \item  Write a function to compute equilibrium simulations based on NASA $CO_2$ data from 1980 to the present. Plot the results.
 


### PR DESCRIPTION
It looks like someone intentionally tried to write the ugliest possible LaTeX code in this file:
1. It says `csmall` in the rendered PDF: 
   <img width="315" height="46" alt="grafik" src="https://github.com/user-attachments/assets/fdd3e80c-6fc4-4e0c-baec-14dc635c2956" />
2. Why?
    <img width="217" height="127" alt="grafik" src="https://github.com/user-attachments/assets/72d73ab2-cec0-45cb-996c-5a89c16ad7de" />
3. `\small\texttt{\detokenize{calc_area_mean_south }}\normalsize` changes the **global** font size to small and then changes it back to normal...
4. `\small\texttt{\detokenize{calc_area_mean_south }}\normalsize` adds a whitespace in small texttt, which doesn't match the whitespace size of the regular text.